### PR TITLE
解决移动网络下ijkplayer播放视频手动快进时出现的卡顿问题

### DIFF
--- a/app/src/main/java/com/github/tvbox/osc/player/IjkMediaPlayer.java
+++ b/app/src/main/java/com/github/tvbox/osc/player/IjkMediaPlayer.java
@@ -44,6 +44,9 @@ public class IjkMediaPlayer extends IjkPlayer {
         }
         //开启内置字幕
         mMediaPlayer.setOption(tv.danmaku.ijk.media.player.IjkMediaPlayer.OPT_CATEGORY_PLAYER, "subtitle", 1);
+
+        mMediaPlayer.setOption(tv.danmaku.ijk.media.player.IjkMediaPlayer.OPT_CATEGORY_FORMAT, "dns_cache_clear", 1);
+        mMediaPlayer.setOption(tv.danmaku.ijk.media.player.IjkMediaPlayer.OPT_CATEGORY_FORMAT, "dns_cache_timeout", -1);
     }
 
     @Override


### PR DESCRIPTION
山东移动宽带网络
参考 https://github.com/bilibili/ijkplayer/issues/4965