### PR TITLE
新增弹幕搜索扩展入口

### DIFF
--- a/app/src/main/java/com/github/catvod/crawler/JarLoader.java
+++ b/app/src/main/java/com/github/catvod/crawler/JarLoader.java
@@ -34,6 +34,8 @@ import okhttp3.Response;
 public class JarLoader {
     private final ConcurrentHashMap<String, DexClassLoader> classLoaders = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, Method> proxyMethods = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Method> danmuClickMethods = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Method> danmuLongClickMethods = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, Spider> spiders = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, String> siteJarKeys = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, Boolean> protectedInitJars = new ConcurrentHashMap<>();
@@ -69,6 +71,8 @@ public class JarLoader {
     public void clear() {
         spiders.clear();
         proxyMethods.clear();
+        danmuClickMethods.clear();
+        danmuLongClickMethods.clear();
         classLoaders.clear();
         siteJarKeys.clear();
     }
@@ -123,6 +127,20 @@ public class JarLoader {
                         } catch (Throwable th) {
                             // 可以记录错误日志
                             th.printStackTrace();
+                        }
+                        try {
+                            Class<?> danmaku = classLoader.loadClass("com.github.catvod.spider.Danmaku");
+                            try {
+                                Method clickMethod = danmaku.getMethod("onClick", String.class, String.class);
+                                danmuClickMethods.put(key, clickMethod);
+                            } catch (Throwable ignored) {
+                            }
+                            try {
+                                Method longClickMethod = danmaku.getMethod("onLongClick", String.class, String.class);
+                                danmuLongClickMethods.put(key, longClickMethod);
+                            } catch (Throwable ignored) {
+                            }
+                        } catch (Throwable ignored) {
                         }
                         break;
                     }
@@ -427,6 +445,19 @@ public class JarLoader {
             th.printStackTrace();
         }
         return new SpiderNull();
+    }
+
+    public void searchDanmuUi(String name, String episode, boolean longClick) {
+        try {
+            ConcurrentHashMap<String, Method> methods = longClick ? danmuLongClickMethods : danmuClickMethods;
+            Method method = methods.get(recentJarKey);
+            if (method == null) method = methods.get("main");
+            if (method == null) return;
+            method.invoke(null, name, episode);
+        } catch (Throwable th) {
+            Log.i("JarLoader", "echo-searchDanmuUi error key=" + name + ", episode=" + episode + ", longClick=" + longClick + ", msg=" + th.getMessage());
+            th.printStackTrace();
+        }
     }
 
     private String getJarKey(String jar) {

--- a/app/src/main/java/com/github/tvbox/osc/api/ApiConfig.java
+++ b/app/src/main/java/com/github/tvbox/osc/api/ApiConfig.java
@@ -96,6 +96,7 @@ public class ApiConfig {
     private final Gson gson;
     private final Handler mainHandler = new Handler(Looper.getMainLooper());
     private final ExecutorService jarLoadExecutor = Executors.newSingleThreadExecutor();
+    private final ExecutorService danmuSearchExecutor = Executors.newSingleThreadExecutor();
 
     private final String userAgent = "okhttp/3.15";
 
@@ -1425,6 +1426,17 @@ public class ApiConfig {
 
     public Spider getLiveCSP(String url) {
         return url.contains(".js") ? getJsCSP(url) : getPyCSP(url);
+    }
+
+    public void searchDanmuUi(String name, String episode, boolean longClick) {
+        danmuSearchExecutor.execute(() -> {
+            try {
+                jarLoader.searchDanmuUi(name, episode, longClick);
+            } catch (Throwable th) {
+                LOG.e("ApiConfig searchDanmuUi error: " + th.getMessage());
+                th.printStackTrace();
+            }
+        });
     }
 
     public int getLiveConnectTimeoutSeconds() {

--- a/app/src/main/java/com/github/tvbox/osc/player/controller/VodController.java
+++ b/app/src/main/java/com/github/tvbox/osc/player/controller/VodController.java
@@ -171,6 +171,7 @@ public class VodController extends BaseController {
     TextView mZimuBtn;
     TextView mAudioTrackBtn;
     TextView mDanmuSettingBtn;
+    TextView mDanmuSearchUiBtn;
     public TextView mLandscapePortraitBtn;
     private View backBtn;//返回键
     private boolean isClickBackBtn;
@@ -255,6 +256,7 @@ public class VodController extends BaseController {
         mZimuBtn = findViewById(R.id.zimu_select);
         mAudioTrackBtn = findViewById(R.id.audio_track_select);
         mDanmuSettingBtn = findViewById(R.id.danmu_setting);
+        mDanmuSearchUiBtn = findViewById(R.id.danmu_search_ui);
         mLandscapePortraitBtn = findViewById(R.id.landscape_portrait);
         backBtn = findViewById(R.id.tv_back);
         seekTime = findViewById(R.id.tv_seek_time);
@@ -677,6 +679,21 @@ public class VodController extends BaseController {
                 listener.showDanmuSetting();
             }
         });
+        mDanmuSearchUiBtn.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                listener.searchDanmuUi(false);
+                hideBottom();
+            }
+        });
+        mDanmuSearchUiBtn.setOnLongClickListener(new OnLongClickListener() {
+            @Override
+            public boolean onLongClick(View view) {
+                listener.searchDanmuUi(true);
+                hideBottom();
+                return true;
+            }
+        });
         mLandscapePortraitBtn.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -844,6 +861,8 @@ public class VodController extends BaseController {
         void selectAudioTrack();
 
         void showDanmuSetting();
+
+        void searchDanmuUi(boolean longClick);
 
         void startPlayUrl(String url, HashMap<String, String> headers);
 

--- a/app/src/main/java/com/github/tvbox/osc/ui/activity/PlayActivity.java
+++ b/app/src/main/java/com/github/tvbox/osc/ui/activity/PlayActivity.java
@@ -240,6 +240,12 @@ public class PlayActivity extends BaseActivity {
             }
 
             @Override
+            public void searchDanmuUi(boolean longClick) {
+                VodInfo.VodSeries series = mVodInfo == null ? null : getCurrentSeries(mVodInfo.playFlag, mVodInfo.playIndex);
+                ApiConfig.get().searchDanmuUi(mVodInfo == null ? "" : mVodInfo.name, series == null ? "" : series.name, longClick);
+            }
+
+            @Override
             public void playNext(boolean rmProgress) {
                 String preProgressKey = progressKey;
                 PlayActivity.this.playNext(rmProgress);

--- a/app/src/main/java/com/github/tvbox/osc/ui/fragment/PlayFragment.java
+++ b/app/src/main/java/com/github/tvbox/osc/ui/fragment/PlayFragment.java
@@ -279,6 +279,12 @@ public class PlayFragment extends BaseLazyFragment {
             }
 
             @Override
+            public void searchDanmuUi(boolean longClick) {
+                VodInfo.VodSeries series = mVodInfo == null ? null : getCurrentSeries(mVodInfo.playFlag, mVodInfo.playIndex);
+                ApiConfig.get().searchDanmuUi(mVodInfo == null ? "" : mVodInfo.name, series == null ? "" : series.name, longClick);
+            }
+
+            @Override
             public void playNext(boolean rmProgress) {
                 String preProgressKey = progressKey;
                 PlayFragment.this.playNext(rmProgress);

--- a/app/src/main/res/layout/player_vod_control_view.xml
+++ b/app/src/main/res/layout/player_vod_control_view.xml
@@ -406,6 +406,19 @@
                 android:visibility="gone" />
 
             <TextView
+                android:id="@+id/danmu_search_ui"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="@dimen/vs_5"
+                android:layout_marginRight="@dimen/vs_5"
+                android:background="@drawable/button_dialog_main"
+                android:focusable="true"
+                android:padding="@dimen/vs_10"
+                android:text="弹幕搜索"
+                android:textColor="@android:color/white"
+                android:textSize="@dimen/ts_20"/>
+
+            <TextView
                 android:id="@+id/landscape_portrait"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"


### PR DESCRIPTION
### 修改内容

新增播放器弹幕搜索扩展入口：

- 在播放器控制栏增加“弹幕搜索”按钮，并放置在“弹幕”按钮之后
- 点击按钮调用外部 Dex 中的 `com.github.catvod.spider.Danmaku.onClick(String name, String episode)`
- 长按按钮调用外部 Dex 中的 `com.github.catvod.spider.Danmaku.onLongClick(String name, String episode)`
- 传入当前影片名称和当前集数名称
- 通过 `ApiConfig` 使用单线程异步执行，避免阻塞播放器 UI
- `JarLoader` 中按 jar key 缓存反射方法，优先使用当前 jar，找不到时回退到 `main`

### 设计说明

App 端只提供播放器入口和当前影片信息，具体弹幕搜索、展示、推送等逻辑由外部 Dex 实现。

外部 Dex 可选实现类：

`com.github.catvod.spider.Danmaku`

可选实现方法：

- `public static void onClick(String name, String episode)`
- `public static void onLongClick(String name, String episode)`

如果外部 Dex 没有实现对应方法，则点击后不执行任何操作，不影响原有播放逻辑。

### 影响范围

仅涉及播放器弹幕搜索扩展入口，不改变原有播放、搜索、解析逻辑。